### PR TITLE
Add multi-release AEI support and 1P API processing

### DIFF
--- a/aggregate.py
+++ b/aggregate.py
@@ -8,9 +8,13 @@ apportionment approaches:
 Saves checkpoints at each stage.
 """
 
+import logging
 from pathlib import Path
 
 import pandas as pd
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+logger = logging.getLogger(__name__)
 
 BASE = Path(__file__).resolve().parent
 MERGED_CSV = BASE / "data" / "merged.csv"
@@ -32,14 +36,14 @@ COUNT_COLS = [f"{t}_count" for t in COLLAB_TYPES]
 # ==========================================================================
 df = pd.read_csv(MERGED_CSV)
 df["task_key"] = df["Task"].str.lower().str.strip()
-print(f"Loaded {len(df)} task-occupation rows")
-print(f"  Unique tasks: {df['task_key'].nunique()}")
-print(f"  Unique SOC 2010 occupations: {df['soc_2010'].nunique()}")
+logger.info("Loaded %d task-occupation rows", len(df))
+logger.info("  Unique tasks: %d", df["task_key"].nunique())
+logger.info("  Unique SOC 2010 occupations: %d", df["soc_2010"].nunique())
 
 # ==========================================================================
 # Approach 1: Equal weighting
 # ==========================================================================
-print("\n--- Approach 1: Equal weighting ---")
+logger.info("--- Approach 1: Equal weighting ---")
 
 # Count how many occupations each task maps to
 n_occs_per_task = df.groupby("task_key")["soc_2010"].nunique().rename("n_occs_per_task")
@@ -74,18 +78,18 @@ emp_cols = ["soc_2010", "apportioned_occ_emp", "coarsened_group_a_mean"]
 emp = df[emp_cols].drop_duplicates("soc_2010")
 occ_equal = occ_equal.merge(emp, on="soc_2010", how="left")
 
-print(f"  Occupations: {len(occ_equal)}")
-print(f"  With AEI data: {(occ_equal['equal_task_count'] > 0).sum()}")
+logger.info("  Occupations: %d", len(occ_equal))
+logger.info("  With AEI data: %d", (occ_equal["equal_task_count"] > 0).sum())
 total_equal = occ_equal["equal_task_count"].sum()
-print(f"  Total apportioned task_count: {total_equal:,.0f}")
+logger.info("  Total apportioned task_count: %s", f"{total_equal:,.0f}")
 
 occ_equal.to_csv(OUT_DIR / "occ_equal_weighted.csv", index=False)
-print(f"  Saved to {OUT_DIR / 'occ_equal_weighted.csv'}")
+logger.info("  Saved to %s", OUT_DIR / "occ_equal_weighted.csv")
 
 # ==========================================================================
 # Approach 2: Employment weighting
 # ==========================================================================
-print("\n--- Approach 2: Employment weighting ---")
+logger.info("--- Approach 2: Employment weighting ---")
 
 # Total employment across all occupations sharing each task
 task_total_emp = (
@@ -127,18 +131,18 @@ occ_emp["automation_ratio"] = (
 # Add employment and wage data
 occ_emp = occ_emp.merge(emp, on="soc_2010", how="left")
 
-print(f"  Occupations: {len(occ_emp)}")
-print(f"  With AEI data: {(occ_emp['emp_task_count'] > 0).sum()}")
+logger.info("  Occupations: %d", len(occ_emp))
+logger.info("  With AEI data: %d", (occ_emp["emp_task_count"] > 0).sum())
 total_emp_weighted = occ_emp["emp_task_count"].sum()
-print(f"  Total apportioned task_count: {total_emp_weighted:,.0f}")
+logger.info("  Total apportioned task_count: %s", f"{total_emp_weighted:,.0f}")
 
 occ_emp.to_csv(OUT_DIR / "occ_emp_weighted.csv", index=False)
-print(f"  Saved to {OUT_DIR / 'occ_emp_weighted.csv'}")
+logger.info("  Saved to %s", OUT_DIR / "occ_emp_weighted.csv")
 
 # ==========================================================================
 # Comparison
 # ==========================================================================
-print("\n--- Comparison ---")
+logger.info("--- Comparison ---")
 equal_compare_cols = [
     "soc_2010",
     "equal_task_count",
@@ -159,6 +163,6 @@ both = occ_equal[equal_compare_cols].merge(
 has_data = both[(both["equal_task_count"] > 0) & (both["emp_task_count"] > 0)]
 auto_corr = has_data["automation_ratio_equal"].corr(has_data["automation_ratio_emp"])
 aug_corr = has_data["augmentation_ratio_equal"].corr(has_data["augmentation_ratio_emp"])
-print(f"  Occupations with data in both: {len(has_data)}")
-print(f"  Automation ratio correlation: {auto_corr:.4f}")
-print(f"  Augmentation ratio correlation: {aug_corr:.4f}")
+logger.info("  Occupations with data in both: %d", len(has_data))
+logger.info("  Automation ratio correlation: %.4f", auto_corr)
+logger.info("  Augmentation ratio correlation: %.4f", aug_corr)

--- a/anthropic/clean.py
+++ b/anthropic/clean.py
@@ -64,29 +64,11 @@ def clean_aei(raw_path: Path, release: str, platform: str) -> pd.DataFrame:
     raw = raw[raw["geo_id"] == "GLOBAL"]
     logger.info("  After GLOBAL filter: %d rows", len(raw))
 
-    # --- Validation: total conversation count ---
-    usage_all = raw[raw["facet"] == "onet_task"]
-    if not usage_all.empty:
-        total_count = usage_all.loc[
-            usage_all["variable"] == "onet_task_count", "value"
-        ].sum()
-        logger.info("  Total onet_task count (all usage): %s", f"{int(total_count):,}")
-    else:
-        logger.warning("  No onet_task facet found — cannot validate total count")
-
     # --- Collaboration data ---
     df = raw[raw["facet"] == "onet_task::collaboration"].copy()
     if df.empty:
         logger.warning("  No onet_task::collaboration rows — skipping")
         return pd.DataFrame()
-
-    collab_total = df.loc[
-        df["variable"] == "onet_task_collaboration_count", "value"
-    ].sum()
-    logger.info(
-        "  Collaboration sample: %s conversation-type pairs",
-        f"{int(collab_total):,}",
-    )
 
     # --- Task usage totals (from onet_task facet) ---
     usage = raw[raw["facet"] == "onet_task"].copy()
@@ -109,8 +91,6 @@ def clean_aei(raw_path: Path, release: str, platform: str) -> pd.DataFrame:
         .reset_index()
         .rename(columns={"cluster_name": "task"})
     )
-    sample_size = int(usage_wide["task_count"].sum())
-    logger.info("  Sample size: %s conversations", f"{sample_size:,}")
 
     # --- Parse cluster_name ---
     df["task"] = df["cluster_name"].str.rsplit("::", n=1).str[0]
@@ -164,6 +144,17 @@ def clean_aei(raw_path: Path, release: str, platform: str) -> pd.DataFrame:
     available_count = [c for c in COUNT_COLS if c in wide.columns]
     available_pct = [c for c in PCT_COLS if c in wide.columns]
     wide = wide[["task", "task_count", "task_pct"] + available_count + available_pct]
+
+    # --- Validation ---
+    total_count = int(wide["task_count"].sum())
+    logger.info("  Total conversations (after facet filter): %s", f"{total_count:,}")
+    top = wide.nlargest(3, "task_count")[["task", "task_count"]]
+    for _, row in top.iterrows():
+        logger.info(
+            "    max: %s (%s)",
+            f"{int(row['task_count']):,}",
+            row["task"][:80],
+        )
 
     logger.info("  Output: %d tasks", len(wide))
     return wide

--- a/anthropic/clean.py
+++ b/anthropic/clean.py
@@ -108,7 +108,9 @@ def clean_aei(raw_path: Path, release: str, platform: str) -> pd.DataFrame:
         return pd.DataFrame()
 
     wide = (
-        df.pivot_table(index="task", columns="col_name", values="value", aggfunc="first")
+        df.pivot_table(
+            index="task", columns="col_name", values="value", aggfunc="first"
+        )
         .fillna(0)
         .reset_index()
     )

--- a/anthropic/clean.py
+++ b/anthropic/clean.py
@@ -1,98 +1,20 @@
-"""Clean the AEI Claude.ai data: filter and pivot wide."""
+"""Clean AEI raw data: filter to GLOBAL, pivot collaboration counts wide.
 
+Processes all releases × platforms (Claude AI and 1P API), outputting one
+cleaned CSV per release-platform combination.
+"""
+
+import logging
 from pathlib import Path
 
 import pandas as pd
 
-# --- Config ---
-RELEASE = "release_2026_03_24"
+logger = logging.getLogger(__name__)
+
 BASE = Path(__file__).resolve().parent.parent
-RAW_CSV = BASE / "data" / RELEASE / "aei_raw_claude_ai_2026-02-05_to_2026-02-12.csv"
-OUT_CSV = BASE / "data" / RELEASE / "aei_cleaned_claude_ai.csv"
+DATA = BASE / "data"
 
-# --- Load & Filter ---
-raw = pd.read_csv(RAW_CSV)
-# TODO: add country-level geo_ids once we decide how to handle aggregation
-raw = raw[raw["geo_id"] == "GLOBAL"]
-
-df = raw[raw["facet"] == "onet_task::collaboration"].copy()
-collab_total = df.loc[df["variable"] == "onet_task_collaboration_count", "value"].sum()
-print(f"Collaboration sample: {int(collab_total):,} conversation-type pairs")
-
-# --- Task usage totals (from onet_task facet) ---
-usage = raw[raw["facet"] == "onet_task"].copy()
-usage["var_short"] = usage["variable"].str.replace("onet_task_", "")
-usage_dupes = usage.duplicated(subset=["cluster_name", "var_short"], keep=False)
-assert not usage_dupes.any(), (
-    "Duplicate (cluster_name, var_short) pairs:\n"
-    f"{usage.loc[usage_dupes, ['cluster_name', 'var_short']]}"
-)
-usage_wide = (
-    usage.pivot_table(
-        index="cluster_name",
-        columns="var_short",
-        values="value",
-        aggfunc="first",
-    )
-    .rename(columns={"count": "task_count", "pct": "task_pct"})
-    .reset_index()
-    .rename(columns={"cluster_name": "task"})
-)
-print(f"Sample size: {int(usage_wide['task_count'].sum()):,} conversations")
-
-# --- Parse cluster_name ---
-df["task"] = df["cluster_name"].str.rsplit("::", n=1).str[0]
-df["collaboration_type"] = df["cluster_name"].str.rsplit("::", n=1).str[1]
-df["collaboration_type"] = df["collaboration_type"].str.replace(" ", "_")
-
-# Shorten variable names: "onet_task_collaboration_count" -> "count"
-df["var_short"] = df["variable"].str.replace("onet_task_collaboration_", "")
-df["col_name"] = df["collaboration_type"] + "_" + df["var_short"]
-
-# --- Pivot Wide ---
-dupes = df.duplicated(subset=["task", "col_name"], keep=False)
-assert not dupes.any(), (
-    f"Duplicate (task, col_name) pairs:\n{df.loc[dupes, ['task', 'col_name']]}"
-)
-
-wide = (
-    df.pivot_table(index="task", columns="col_name", values="value", aggfunc="first")
-    .fillna(0)
-    .reset_index()
-)
-
-# --- Merge task usage totals ---
-usage_wide["task_merge_key"] = usage_wide["task"].str.lower().str.strip()
-wide["task_merge_key"] = wide["task"].str.lower().str.strip()
-wide_keys = set(wide["task_merge_key"])
-usage_keys = set(usage_wide["task_merge_key"])
-usage_unmatched = usage_keys - wide_keys
-print("\n--- Task usage merge ---")
-print(f"  Usage tasks: {len(usage_keys)}")
-print(f"  AEI tasks: {len(wide_keys)}")
-print(f"  Usage tasks not in AEI (dropped from right): {len(usage_unmatched)}")
-if usage_unmatched:
-    for t in sorted(usage_unmatched):
-        print(f"    - {t!r}")
-aei_unmatched_usage = wide_keys - usage_keys
-if aei_unmatched_usage:
-    print(
-        f"  AEI tasks not in usage (null task_count/task_pct): "
-        f"{len(aei_unmatched_usage)}"
-    )
-    for t in sorted(aei_unmatched_usage):
-        print(f"    - {t!r}")
-
-wide = wide.merge(
-    usage_wide[["task_merge_key", "task_count", "task_pct"]],
-    on="task_merge_key",
-    how="left",
-)
-wide = wide.drop(columns=["task_merge_key"])
-print()
-
-# --- Order columns: task, counts, pcts ---
-collab_types = [
+COLLAB_TYPES = [
     "directive",
     "feedback_loop",
     "learning",
@@ -101,10 +23,175 @@ collab_types = [
     "task_iteration",
     "validation",
 ]
-count_cols = [f"{t}_count" for t in collab_types]
-pct_cols = [f"{t}_pct" for t in collab_types]
-wide = wide[["task", "task_count", "task_pct"] + count_cols + pct_cols]
+COUNT_COLS = [f"{t}_count" for t in COLLAB_TYPES]
+PCT_COLS = [f"{t}_pct" for t in COLLAB_TYPES]
 
-# --- Write ---
-wide.to_csv(OUT_CSV, index=False)
-print(f"Wrote {len(wide)} rows to {OUT_CSV}")
+# Registry: release -> {platform_key: raw_filename}
+RELEASES = {
+    "release_2025_09_15": {
+        "claude_ai": "aei_raw_claude_ai_2025-08-04_to_2025-08-11.csv",
+        "1p_api": "aei_raw_1p_api_2025-08-04_to_2025-08-11.csv",
+    },
+    "release_2026_01_15": {
+        "claude_ai": "aei_raw_claude_ai_2025-11-13_to_2025-11-20.csv",
+        "1p_api": "aei_raw_1p_api_2025-11-13_to_2025-11-20.csv",
+    },
+    "release_2026_03_24": {
+        "claude_ai": "aei_raw_claude_ai_2026-02-05_to_2026-02-12.csv",
+        "1p_api": "aei_raw_1p_api_2026-02-05_to_2026-02-12.csv",
+    },
+}
+
+
+def clean_aei(raw_path: Path, release: str, platform: str) -> pd.DataFrame:
+    """Clean a single AEI raw file: filter to GLOBAL, pivot collaboration wide.
+
+    Parameters
+    ----------
+    raw_path : Path to the raw CSV file
+    release : Release identifier (for logging)
+    platform : Platform key ("claude_ai" or "1p_api")
+
+    Returns
+    -------
+    DataFrame with columns: task, task_count, task_pct, {collab_type}_{count,pct}
+    """
+    logger.info("[%s / %s] Loading %s", release, platform, raw_path.name)
+    raw = pd.read_csv(raw_path)
+    logger.info("  Raw rows: %d", len(raw))
+
+    # Filter to GLOBAL
+    raw = raw[raw["geo_id"] == "GLOBAL"]
+    logger.info("  After GLOBAL filter: %d rows", len(raw))
+
+    # --- Validation: total conversation count ---
+    usage_all = raw[raw["facet"] == "onet_task"]
+    if not usage_all.empty:
+        total_count = usage_all.loc[
+            usage_all["variable"] == "onet_task_count", "value"
+        ].sum()
+        logger.info("  Total onet_task count (all usage): %s", f"{int(total_count):,}")
+    else:
+        logger.warning("  No onet_task facet found — cannot validate total count")
+
+    # --- Collaboration data ---
+    df = raw[raw["facet"] == "onet_task::collaboration"].copy()
+    if df.empty:
+        logger.warning("  No onet_task::collaboration rows — skipping")
+        return pd.DataFrame()
+
+    collab_total = df.loc[
+        df["variable"] == "onet_task_collaboration_count", "value"
+    ].sum()
+    logger.info(
+        "  Collaboration sample: %s conversation-type pairs",
+        f"{int(collab_total):,}",
+    )
+
+    # --- Task usage totals (from onet_task facet) ---
+    usage = raw[raw["facet"] == "onet_task"].copy()
+    usage["var_short"] = usage["variable"].str.replace("onet_task_", "")
+    usage_dupes = usage.duplicated(subset=["cluster_name", "var_short"], keep=False)
+    if usage_dupes.any():
+        logger.error(
+            "  Duplicate (cluster_name, var_short) pairs found — aborting this file"
+        )
+        return pd.DataFrame()
+
+    usage_wide = (
+        usage.pivot_table(
+            index="cluster_name",
+            columns="var_short",
+            values="value",
+            aggfunc="first",
+        )
+        .rename(columns={"count": "task_count", "pct": "task_pct"})
+        .reset_index()
+        .rename(columns={"cluster_name": "task"})
+    )
+    sample_size = int(usage_wide["task_count"].sum())
+    logger.info("  Sample size: %s conversations", f"{sample_size:,}")
+
+    # --- Parse cluster_name ---
+    df["task"] = df["cluster_name"].str.rsplit("::", n=1).str[0]
+    df["collaboration_type"] = df["cluster_name"].str.rsplit("::", n=1).str[1]
+    df["collaboration_type"] = df["collaboration_type"].str.replace(" ", "_")
+
+    # Shorten variable names
+    df["var_short"] = df["variable"].str.replace("onet_task_collaboration_", "")
+    df["col_name"] = df["collaboration_type"] + "_" + df["var_short"]
+
+    # --- Pivot Wide ---
+    dupes = df.duplicated(subset=["task", "col_name"], keep=False)
+    if dupes.any():
+        logger.error("  Duplicate (task, col_name) pairs — aborting this file")
+        return pd.DataFrame()
+
+    wide = (
+        df.pivot_table(index="task", columns="col_name", values="value", aggfunc="first")
+        .fillna(0)
+        .reset_index()
+    )
+
+    # --- Merge task usage totals ---
+    usage_wide["task_merge_key"] = usage_wide["task"].str.lower().str.strip()
+    wide["task_merge_key"] = wide["task"].str.lower().str.strip()
+    wide_keys = set(wide["task_merge_key"])
+    usage_keys = set(usage_wide["task_merge_key"])
+
+    usage_unmatched = usage_keys - wide_keys
+    if usage_unmatched:
+        logger.info(
+            "  Usage tasks not in collaboration (dropped): %d", len(usage_unmatched)
+        )
+
+    aei_unmatched = wide_keys - usage_keys
+    if aei_unmatched:
+        logger.info(
+            "  Collaboration tasks not in usage (null task_count): %d",
+            len(aei_unmatched),
+        )
+
+    wide = wide.merge(
+        usage_wide[["task_merge_key", "task_count", "task_pct"]],
+        on="task_merge_key",
+        how="left",
+    )
+    wide = wide.drop(columns=["task_merge_key"])
+
+    # --- Order columns ---
+    # Handle case where not all collab types are present
+    available_count = [c for c in COUNT_COLS if c in wide.columns]
+    available_pct = [c for c in PCT_COLS if c in wide.columns]
+    wide = wide[["task", "task_count", "task_pct"] + available_count + available_pct]
+
+    logger.info("  Output: %d tasks", len(wide))
+    return wide
+
+
+def clean_all() -> None:
+    """Process all releases and platforms."""
+    for release, platforms in RELEASES.items():
+        for platform, filename in platforms.items():
+            raw_path = DATA / release / filename
+            if not raw_path.exists():
+                logger.warning(
+                    "[%s / %s] Raw file not found: %s — skipping",
+                    release,
+                    platform,
+                    raw_path,
+                )
+                continue
+
+            wide = clean_aei(raw_path, release, platform)
+            if wide.empty:
+                continue
+
+            out_path = DATA / release / f"aei_cleaned_{platform}.csv"
+            wide.to_csv(out_path, index=False)
+            logger.info("[%s / %s] Wrote %s", release, platform, out_path)
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+    clean_all()

--- a/anthropic/download.py
+++ b/anthropic/download.py
@@ -1,36 +1,71 @@
-"""Download Anthropic Economic Index release data.
+"""Download Anthropic Economic Index release data from Hugging Face.
 
 Source: https://huggingface.co/datasets/Anthropic/EconomicIndex
 """
 
 import json
+import logging
 import urllib.request
 from datetime import datetime, timezone
 from pathlib import Path
 
-RELEASE = "release_2026_03_24"
-API = f"https://huggingface.co/api/datasets/Anthropic/EconomicIndex/tree/main/{RELEASE}/data"
-BASE = f"https://huggingface.co/datasets/Anthropic/EconomicIndex/resolve/main/{RELEASE}/data"
+logger = logging.getLogger(__name__)
 
-OUT = Path(__file__).resolve().parent.parent / "data" / RELEASE
-OUT.mkdir(parents=True, exist_ok=True)
+BASE_URL = "https://huggingface.co/datasets/Anthropic/EconomicIndex/resolve/main"
+API_URL = "https://huggingface.co/api/datasets/Anthropic/EconomicIndex/tree/main"
 
-with urllib.request.urlopen(API) as resp:
-    entries = json.load(resp)
-names = [Path(e["path"]).name for e in entries if e.get("type") == "file"]
+# Registry of releases and their data paths relative to the release root.
+# Older releases store data in data/intermediate/, newer ones in data/.
+RELEASES = {
+    "release_2025_09_15": "data/intermediate",
+    "release_2026_01_15": "data/intermediate",
+    "release_2026_03_24": "data",
+}
 
-for name in names:
-    print(f"downloading {name}...")
-    urllib.request.urlretrieve(f"{BASE}/{name}", OUT / name)
+OUT_BASE = Path(__file__).resolve().parent.parent / "data"
 
-(OUT / "metadata.json").write_text(
-    json.dumps(
-        {
-            "release": RELEASE,
-            "fetched_at": datetime.now(timezone.utc).isoformat(),
-            "files": names,
-        },
-        indent=2,
+
+def download_release(release: str, data_subpath: str) -> None:
+    """Download all files for a single release."""
+    api = f"{API_URL}/{release}/{data_subpath}"
+    out_dir = OUT_BASE / release
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    logger.info("Fetching file list for %s", release)
+    with urllib.request.urlopen(api) as resp:
+        entries = json.load(resp)
+    names = [Path(e["path"]).name for e in entries if e.get("type") == "file"]
+
+    base = f"{BASE_URL}/{release}/{data_subpath}"
+    for name in names:
+        dest = out_dir / name
+        if dest.exists():
+            logger.info("  %s (already exists, skipping)", name)
+            continue
+        logger.info("  downloading %s...", name)
+        urllib.request.urlretrieve(f"{base}/{name}", dest)
+
+    (out_dir / "metadata.json").write_text(
+        json.dumps(
+            {
+                "release": release,
+                "data_subpath": data_subpath,
+                "fetched_at": datetime.now(timezone.utc).isoformat(),
+                "files": names,
+            },
+            indent=2,
+        )
+        + "\n"
     )
-    + "\n"
-)
+    logger.info("Done: %s (%d files)", release, len(names))
+
+
+def download_all() -> None:
+    """Download all registered releases."""
+    for release, subpath in RELEASES.items():
+        download_release(release, subpath)
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+    download_all()

--- a/merge.py
+++ b/merge.py
@@ -137,7 +137,10 @@ if n_oews_ungrouped > 0:
     logger.info("  OEWS codes not in crosswalk:")
     for _, row in oews[oews["group_id"].isna()].iterrows():
         logger.info(
-            "    - %s %s (emp: %s)", row["occ_code"], row["occ_title"], f"{row['tot_emp']:,.0f}"
+            "    - %s %s (emp: %s)",
+            row["occ_code"],
+            row["occ_title"],
+            f"{row['tot_emp']:,.0f}",
         )
 
 # --- Step 3b: Coarsened crosswalk for broad codes on either side ---
@@ -231,7 +234,11 @@ for mc in merged_coarsenings:
 
     label_str = " + ".join(mc["labels"])
     logger.info(
-        "  %s -> group %d (merged %s; %s)", label_str, new_gid, child_groups, mc["detail"]
+        "  %s -> group %d (merged %s; %s)",
+        label_str,
+        new_gid,
+        child_groups,
+        mc["detail"],
     )
     coarsened_count += 1
 

--- a/merge.py
+++ b/merge.py
@@ -1,10 +1,14 @@
 """Merge O*NET task frame with AEI usage and OEWS employment data."""
 
+import logging
 from pathlib import Path
 
 import networkx as nx
 import numpy as np
 import pandas as pd
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+logger = logging.getLogger(__name__)
 
 BASE = Path(__file__).resolve().parent
 
@@ -29,19 +33,19 @@ aei["task_merge_key"] = aei["task"].str.lower().str.strip()
 aei_keys = set(aei["task_merge_key"])
 onet_keys = set(onet["task_merge_key"])
 
-print("--- Step 1: O*NET ← AEI ---")
-print(f"  O*NET tasks (unique text): {len(onet_keys)}")
-print(f"  AEI tasks (unique text): {len(aei_keys)}")
-print(f"  Matched: {len(onet_keys & aei_keys)}")
+logger.info("--- Step 1: O*NET ← AEI ---")
+logger.info("  O*NET tasks (unique text): %d", len(onet_keys))
+logger.info("  AEI tasks (unique text): %d", len(aei_keys))
+logger.info("  Matched: %d", len(onet_keys & aei_keys))
 
 aei_only = aei_keys - onet_keys
 if aei_only:
-    print(f"  AEI tasks not in O*NET (dropped): {len(aei_only)}")
+    logger.info("  AEI tasks not in O*NET (dropped): %d", len(aei_only))
     for t in sorted(aei_only):
-        print(f"    - {t!r}")
+        logger.info("    - %r", t)
 
 onet_only = onet_keys - aei_keys
-print(f"  O*NET tasks not in AEI (zero-filled): {len(onet_only)}")
+logger.info("  O*NET tasks not in AEI (zero-filled): %d", len(onet_only))
 
 aei = aei.drop(columns=["task"])
 tasks = onet.merge(aei, on="task_merge_key", how="left")
@@ -54,9 +58,11 @@ tasks[fill_cols] = tasks[fill_cols].fillna(0)
 
 n_with_aei = tasks["task_count"].gt(0).sum()
 n_without_aei = tasks["task_count"].eq(0).sum()
-print(
-    f"  Result: {len(tasks)} rows "
-    f"({n_with_aei} with AEI data, {n_without_aei} zero-filled)"
+logger.info(
+    "  Result: %d rows (%d with AEI data, %d zero-filled)",
+    len(tasks),
+    n_with_aei,
+    n_without_aei,
 )
 
 # ==========================================================================
@@ -69,8 +75,8 @@ tasks = tasks.merge(g2010[["soc_2010", "group_id"]], on="soc_2010", how="left")
 
 n_grouped = tasks["group_id"].notna().sum()
 n_ungrouped = tasks["group_id"].isna().sum()
-print("\n--- Step 2: SOC 2010 → group_id ---")
-print(f"  Tasks grouped: {n_grouped}, ungrouped: {n_ungrouped}")
+logger.info("--- Step 2: SOC 2010 → group_id ---")
+logger.info("  Tasks grouped: %d, ungrouped: %d", n_grouped, n_ungrouped)
 
 # For ungrouped tasks, try prefix match (broad SOC codes like 19-1020).
 # Store broad-code child groups for coarsening in step 3b.
@@ -86,14 +92,18 @@ if n_ungrouped > 0:
             # Temporarily assign first child group; step 3b will coarsen if needed
             tasks.loc[tasks["soc_2010"] == s, "group_id"] = child_groups[0]
             task_broad_codes[s] = child_groups
-            print(
-                f"    - {s} ({title}) -> prefix {prefix}*, child groups: {child_groups}"
+            logger.info(
+                "    - %s (%s) -> prefix %s*, child groups: %s",
+                s,
+                title,
+                prefix,
+                child_groups,
             )
         else:
-            print(f"    - {s} ({title}) -> no match")
+            logger.info("    - %s (%s) -> no match", s, title)
 
 task_group_ids = set(tasks.loc[tasks["group_id"].notna(), "group_id"].astype(int))
-print(f"  Unique groups represented: {len(task_group_ids)}")
+logger.info("  Unique groups represented: %d", len(task_group_ids))
 
 # ==========================================================================
 # Step 3: OEWS ← group_id via SOC 2018 crosswalk
@@ -117,17 +127,17 @@ oews = oews.merge(
 oews_group_ids = set(oews.loc[oews["group_id"].notna(), "group_id"].astype(int))
 n_oews_grouped = oews["group_id"].notna().sum()
 n_oews_ungrouped = oews["group_id"].isna().sum()
-print("\n--- Step 3: OEWS ← group_id ---")
-print(f"  OEWS detailed occupations: {len(oews)}")
-print(f"  Grouped: {n_oews_grouped}, ungrouped: {n_oews_ungrouped}")
-print(f"  Unique groups represented: {len(oews_group_ids)}")
+logger.info("--- Step 3: OEWS ← group_id ---")
+logger.info("  OEWS detailed occupations: %d", len(oews))
+logger.info("  Grouped: %d, ungrouped: %d", n_oews_grouped, n_oews_ungrouped)
+logger.info("  Unique groups represented: %d", len(oews_group_ids))
 if n_oews_ungrouped > 0:
     ungrouped_emp = oews.loc[oews["group_id"].isna(), "tot_emp"].sum()
-    print(f"  Ungrouped employment: {ungrouped_emp:,.0f}")
-    print("  OEWS codes not in crosswalk:")
+    logger.info("  Ungrouped employment: %s", f"{ungrouped_emp:,.0f}")
+    logger.info("  OEWS codes not in crosswalk:")
     for _, row in oews[oews["group_id"].isna()].iterrows():
-        print(
-            f"    - {row['occ_code']} {row['occ_title']} (emp: {row['tot_emp']:,.0f})"
+        logger.info(
+            "    - %s %s (emp: %s)", row["occ_code"], row["occ_title"], f"{row['tot_emp']:,.0f}"
         )
 
 # --- Step 3b: Coarsened crosswalk for broad codes on either side ---
@@ -137,7 +147,7 @@ if n_oews_ungrouped > 0:
 tasks["group_id_coarsened"] = tasks["group_id"].copy()
 oews["group_id_coarsened"] = oews["group_id"].copy()
 
-print("\n--- Step 3b: Coarsened crosswalk for broad codes ---")
+logger.info("--- Step 3b: Coarsened crosswalk for broad codes ---")
 next_group_id = int(max(g2010["group_id"].max(), g2018["group_id"].max())) + 1
 coarsened_count = 0
 
@@ -150,7 +160,7 @@ for _, row in oews[oews["group_id_coarsened"].isna()].iterrows():
     prefix = code[:6]
     children = g2018[g2018["soc_2018"].str.startswith(prefix)]
     if children.empty:
-        print(f"  {code}: no children found with prefix {prefix}, skipping")
+        logger.info("  %s: no children found with prefix %s, skipping", code, prefix)
         continue
     child_groups = set(int(g) for g in children["group_id"].unique())
     child_codes = ", ".join(children["soc_2018"].tolist())
@@ -220,10 +230,12 @@ for mc in merged_coarsenings:
     oews.loc[oews["group_id"].isin(child_groups), "group_id_coarsened"] = new_gid
 
     label_str = " + ".join(mc["labels"])
-    print(f"  {label_str} -> group {new_gid} (merged {child_groups}; {mc['detail']})")
+    logger.info(
+        "  %s -> group %d (merged %s; %s)", label_str, new_gid, child_groups, mc["detail"]
+    )
     coarsened_count += 1
 
-print(f"  Coarsened {coarsened_count} OEWS codes")
+logger.info("  Coarsened %d OEWS codes", coarsened_count)
 
 # Recompute group overlap after coarsening
 task_coarsened_ids = set(
@@ -235,10 +247,10 @@ oews_coarsened_ids = set(
 shared_groups = task_coarsened_ids & oews_coarsened_ids
 tasks_only_groups = task_coarsened_ids - oews_coarsened_ids
 oews_only_groups = oews_coarsened_ids - task_coarsened_ids
-print("\n  Group overlap (after coarsening):")
-print(f"    Shared: {len(shared_groups)}")
-print(f"    Task-side only (no OEWS employment): {len(tasks_only_groups)}")
-print(f"    OEWS-side only (no O*NET tasks): {len(oews_only_groups)}")
+logger.info("  Group overlap (after coarsening):")
+logger.info("    Shared: %d", len(shared_groups))
+logger.info("    Task-side only (no OEWS employment): %d", len(tasks_only_groups))
+logger.info("    OEWS-side only (no O*NET tasks): %d", len(oews_only_groups))
 
 # ==========================================================================
 # Step 4: Aggregate OEWS by group_id_coarsened
@@ -269,13 +281,15 @@ oews_by_group["coarsened_group_a_mean"] = (
     oews_with_group.groupby("group_id_coarsened").apply(emp_weighted_mean).values
 )
 
-print("\n--- Step 4: OEWS aggregation by coarsened group ---")
-print(f"  Groups with employment: {len(oews_by_group)}")
-print(f"  Total employment: {oews_by_group['coarsened_group_tot_emp'].sum():,.0f}")
+logger.info("--- Step 4: OEWS aggregation by coarsened group ---")
+logger.info("  Groups with employment: %d", len(oews_by_group))
+logger.info(
+    "  Total employment: %s", f"{oews_by_group['coarsened_group_tot_emp'].sum():,.0f}"
+)
 n_with_wage = oews_by_group["coarsened_group_a_mean"].notna().sum()
 n_without_wage = oews_by_group["coarsened_group_a_mean"].isna().sum()
-print(f"  Groups with wage data: {n_with_wage}")
-print(f"  Groups without wage data: {n_without_wage}")
+logger.info("  Groups with wage data: %d", n_with_wage)
+logger.info("  Groups without wage data: %d", n_without_wage)
 
 # ==========================================================================
 # Step 5: Merge OEWS groups onto task frame
@@ -289,17 +303,18 @@ emp_covered = (
     .drop_duplicates()
     .sum()
 )
-print("\n--- Step 5: Tasks ← OEWS groups ---")
-print(f"  Tasks with employment data: {n_with_emp}")
-print(f"  Tasks without employment data: {n_without_emp}")
-print(f"  Total employment covered: {emp_covered:,.0f}")
+logger.info("--- Step 5: Tasks ← OEWS groups ---")
+logger.info("  Tasks with employment data: %d", n_with_emp)
+logger.info("  Tasks without employment data: %d", n_without_emp)
+logger.info("  Total employment covered: %s", f"{emp_covered:,.0f}")
 if n_without_emp > 0:
     no_emp = tasks.loc[tasks["coarsened_group_tot_emp"].isna()]
     n_with_aei_no_emp = no_emp["task_count"].gt(0).sum()
     n_occ_no_emp = no_emp["O*NET-SOC Code"].nunique()
-    print(
-        f"  Of which have AEI data but no employment: "
-        f"{n_with_aei_no_emp} tasks across {n_occ_no_emp} occupations"
+    logger.info(
+        "  Of which have AEI data but no employment: %d tasks across %d occupations",
+        n_with_aei_no_emp,
+        n_occ_no_emp,
     )
 
 # ==========================================================================
@@ -317,15 +332,15 @@ tasks["apportioned_occ_emp"] = (
     tasks["coarsened_group_tot_emp"] / tasks["n_soc_2010_in_group"]
 )
 
-print("\n--- Step 6: Apportion employment to occupations ---")
+logger.info("--- Step 6: Apportion employment to occupations ---")
 n_occs_with_emp = tasks.loc[tasks["apportioned_occ_emp"].notna(), "soc_2010"].nunique()
 total_apportioned = (
     tasks[tasks["apportioned_occ_emp"].notna()]
     .drop_duplicates("soc_2010")["apportioned_occ_emp"]
     .sum()
 )
-print(f"  SOC 2010 occupations with employment: {n_occs_with_emp}")
-print(f"  Total apportioned employment: {total_apportioned:,.0f}")
+logger.info("  SOC 2010 occupations with employment: %d", n_occs_with_emp)
+logger.info("  Total apportioned employment: %s", f"{total_apportioned:,.0f}")
 
 # ==========================================================================
 # Step 7: Apportion usage counts across task-occupations
@@ -352,16 +367,16 @@ tasks.loc[mask, "apportioned_task_count"] = (
 )
 tasks = tasks.drop(columns=["_task_key"])
 
-print("\n--- Step 7: Apportion usage counts across task-occupations ---")
+logger.info("--- Step 7: Apportion usage counts across task-occupations ---")
 orig_sum = tasks.drop_duplicates("Task")["task_count"].sum()
 apportioned_sum = tasks["apportioned_task_count"].sum()
-print(f"  Original task_count sum (unique tasks): {orig_sum:,.0f}")
-print(f"  Apportioned task_count sum (all rows): {apportioned_sum:,.0f}")
+logger.info("  Original task_count sum (unique tasks): %s", f"{orig_sum:,.0f}")
+logger.info("  Apportioned task_count sum (all rows): %s", f"{apportioned_sum:,.0f}")
 n_split = (tasks["apportioned_task_count"] != tasks["task_count"]).sum()
-print(f"  Task-occupation pairs with split count: {n_split}")
+logger.info("  Task-occupation pairs with split count: %d", n_split)
 
 # ==========================================================================
 # Write
 # ==========================================================================
 tasks.to_csv(OUT_CSV, index=False)
-print(f"\nWrote {len(tasks)} rows -> {OUT_CSV}")
+logger.info("Wrote %d rows -> %s", len(tasks), OUT_CSV)


### PR DESCRIPTION
## Summary
- Refactor `anthropic/clean.py` into reusable `clean_aei()` function that processes all releases × platforms (Claude AI + 1P API), outputting one cleaned CSV per combination
- Refactor `anthropic/download.py` to support a registry of releases with skip-if-exists logic
- Convert all `print()` to `logging` module across `merge.py` and `aggregate.py`
- Adds validation logging: total conversation counts per release/platform

Currently processes 3 releases × 2 platforms = 6 cleaned datasets. The merge pipeline still uses only the Mar 2026 Claude AI release; next step is cross-release correlation analysis and deciding the aggregation strategy.

Closes #12, closes #4

## Test plan
- [x] `uv run anthropic/download.py` downloads all 3 releases
- [x] `uv run anthropic/clean.py` produces 6 cleaned CSVs with expected row counts
- [x] `uv run merge.py` produces identical merged.csv output
- [x] `uv run aggregate.py` produces identical occupation-level outputs

🤖 Generated with [Claude Code](https://claude.com/claude-code)